### PR TITLE
Add redshift data endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1953,6 +1953,27 @@ chime_voice_regions = [
             "us-west-2" => %{}
           }
         },
+        "redshift-data" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "email" => %{
           "endpoints" => %{
             "af-south-1" => %{},
@@ -2718,6 +2739,7 @@ chime_voice_regions = [
         },
         "tagging" => %{"endpoints" => %{"cn-north-1" => %{}, "cn-northwest-1" => %{}}},
         "redshift" => %{"endpoints" => %{"cn-north-1" => %{}, "cn-northwest-1" => %{}}},
+        "redshift-data" => %{"endpoints" => %{"cn-north-1" => %{}, "cn-northwest-1" => %{}}},
         "storagegateway" => %{"endpoints" => %{"cn-north-1" => %{}}},
         "autoscaling" => %{
           "defaults" => %{"protocols" => ["http", "https"]},
@@ -2913,6 +2935,7 @@ chime_voice_regions = [
         },
         "tagging" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "redshift" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
+        "redshift-data" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "storagegateway" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "autoscaling" => %{
           "endpoints" => %{


### PR DESCRIPTION
According to the documentation, sending SQL statements to Redshift is handled with a different API:
https://docs.aws.amazon.com/redshift-data/latest/APIReference/Welcome.html instead of
https://docs.aws.amazon.com/redshift/latest/APIReference/Welcome.html so a new service must be defined in the fork.

Before opening a PR, please make sure you have:

* Run `mix format` using a recent version of Elixir
* Run `mix dialyzer` to make sure the typing is correct
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
