### PR TITLE
Add Bedrock Agent endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -156,6 +156,40 @@ chime_voice_regions = [
             "us-west-2" => %{}
           }
         },
+        "bedrock-agent" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "bedrock"}},
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
+        "bedrock-agent-runtime" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "bedrock"}},
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "connect" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},


### PR DESCRIPTION
Map the Bedrock Agent and Bedrock Agent Runtime endpoints. This allows to start using the services with the `ex_aws` library.

The PR is identical to the one which introduced endpoints for Bedrock and Bedrock Runtime: https://github.com/ex-aws/ex_aws/pull/1023.

The list of supported endpoints relies on
https://docs.aws.amazon.com/general/latest/gr/bedrock.html#bedrock_region.

Before opening a PR, please make sure you have:

* Run `mix format` using a recent version of Elixir
* Run `mix dialyzer` to make sure the typing is correct
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
